### PR TITLE
102. Binary Tree Level Order Traversal

### DIFF
--- a/102/step1.cpp
+++ b/102/step1.cpp
@@ -1,0 +1,36 @@
+/*
+Solve Time: 21:38
+
+Time : O(N^2)
+Space : O(N^2)
+*/
+class Solution {
+ public:
+  vector<vector<int>> levelOrder(TreeNode* root) {
+    if (!root) {
+      return {};
+    }
+    auto left = levelOrder(root->left);
+    auto right = levelOrder(root->right);
+    auto merged_level_vals = merge_two_trees(left, right);
+    vector<vector<int>> level_order = {{root->val}};
+    level_order.insert(level_order.end(), merged_level_vals.begin(), merged_level_vals.end());
+    return level_order;
+  }
+
+ private:
+  vector<vector<int>> merge_two_trees(vector<vector<int>>& left, vector<vector<int>>& right) {
+    vector<vector<int>> merged_levels;
+    for (int i = 0; i < max(left.size(), right.size()); ++i) {
+      vector<int> current_level_vals;
+      if (i < left.size()) {
+        current_level_vals.insert(current_level_vals.end(), left[i].begin(), left[i].end());
+      }
+      if (i < right.size()) {
+        current_level_vals.insert(current_level_vals.end(), right[i].begin(), right[i].end());
+      }
+      merged_levels.push_back(current_level_vals);
+    }
+    return merged_levels;
+  }
+};

--- a/102/step2_1.cpp
+++ b/102/step2_1.cpp
@@ -1,0 +1,37 @@
+/*
+Time : O(N)
+Space : O(N)
+
+再帰を用いずに書いてみる。
+currentはnextとの対比として自然なので使用した。
+XXX_level_nodesはちょっと変数名がくどすぎる気もしたが、今見ているlevelというのを強調できるのでcurrent_nodesなどよりも適切に感じる。
+
+*/
+class Solution {
+ public:
+  vector<vector<int>> levelOrder(TreeNode* root) {
+    vector<vector<int>> level_order;
+    queue<TreeNode*> current_level_nodes;
+    queue<TreeNode*> next_level_nodes;
+    current_level_nodes.push(root);
+    while (true) {
+      vector<int> same_level_vals;
+      while (!current_level_nodes.empty()) {
+        auto node = current_level_nodes.front();
+        current_level_nodes.pop();
+        if (!node) {
+          continue;
+        }
+        same_level_vals.push_back(node->val);
+        next_level_nodes.push(node->left);
+        next_level_nodes.push(node->right);
+      }
+      swap(current_level_nodes, next_level_nodes);
+      if (same_level_vals.empty()) {
+        break;
+      }
+      level_order.push_back(same_level_vals);
+    }
+    return level_order;
+  }
+};

--- a/102/step2_2.cpp
+++ b/102/step2_2.cpp
@@ -1,0 +1,25 @@
+class Solution {
+ public:
+  vector<vector<int>> levelOrder(TreeNode* root) {
+    vector<vector<int>> level_ordered_nums;
+    vector<TreeNode*> current_level_nodes = {root};
+    while (!current_level_nodes.empty()) {
+      vector<TreeNode*> next_level_nodes;
+      vector<int> same_level_nums;
+      for (int i = 0; i < current_level_nodes.size(); ++i) {
+        if (!current_level_nodes[i]) {
+          continue;
+        }
+        same_level_nums.push_back(current_level_nodes[i]->val);
+        next_level_nodes.push_back(current_level_nodes[i]->left);
+        next_level_nodes.push_back(current_level_nodes[i]->right);
+      }
+      if (same_level_nums.empty()) {
+        break;
+      }
+      level_ordered_nums.push_back(same_level_nums);
+      swap(current_level_nodes, next_level_nodes);
+    }
+    return level_ordered_nums;
+ }
+};

--- a/102/step3.cpp
+++ b/102/step3.cpp
@@ -1,0 +1,22 @@
+class Solution {
+ public:
+  vector<vector<int>> levelOrder(TreeNode* root) {
+    if (!root) {
+      return {};
+    }
+    vector<vector<int>> level_order = {{root->val}};
+    auto left_level_order = levelOrder(root->left);
+    auto right_level_order = levelOrder(root->right);
+    for (int i = 0; i < max(left_level_order.size(), right_level_order.size()); ++i) {
+      vector<int> same_level_values;
+      if (i < left_level_order.size()) {
+        same_level_values.insert(same_level_values.end(), left_level_order[i].begin(), left_level_order[i].end());
+      }
+      if (i < right_level_order.size()) {
+        same_level_values.insert(same_level_values.end(), right_level_order[i].begin(), right_level_order[i].end());
+      }
+      level_order.push_back(same_level_values);
+    }
+    return level_order;
+  }
+};


### PR DESCRIPTION
https://leetcode.com/problems/binary-tree-level-order-traversal/description/

https://github.com/hayashi-ay/leetcode/pull/32
https://discord.com/channels/1084280443945353267/1200089668901937312/1211248049884499988

<details>
<summary>
leetcode_ahayashi
</summary>

```
私は、while だと思っていて、上から読んでいくと、

「level が大きくて nodes_ordered_by_level が足りない場合、足りるように拡張します。そして、拡張した場所に書き込みます。」(読んでいくと、あとから、足りないことがあったとしても1段であることが他のところから分かる。)

「level が大きくて nodes_ordered_by_level が足りない場合、1段だけ拡張します。そして、level 番目に書き込みます。(書き込めなかったら IndexError が投げられます。)」(読んでいくと、1段だけしか拡張しなくても、level 番目が準備されているので例外はないことが分かる。)

というふうに読めます。どっちが読み手にとっていいですか。

1段だけしか拡張しなくても例外が投げられることがないことに気がつくパズルを解かせる必要ないですよね。そうすると、下にするならば、コメント1行付けておいて、くらいの感覚です。
```

</details>


https://github.com/shining-ai/leetcode/pull/26
https://github.com/Mike0121/LeetCode/pull/7

https://github.com/Mike0121/LeetCode/pull/7#discussion_r1587660995
>私はそもそもローカル変数に current を付けておけばいい名前になっているというのが相当違和感です。current は多くの場合、context のようなグローバルな設定などに用いられる傾向が強く、今注目しているもの、というつもりだと標準的用法からかなりずれを感じます。変数名は長ければ読みやすい訳ではないんです。previous, next との対比ならばまだしも。

https://source.chromium.org/search?q=%22current%22%20-concurrent%20filepath:.*%5C.cc$&start=101

https://github.com/sakupan102/arai60-practice/pull/27
https://github.com/fhiyo/leetcode/pull/28
https://github.com/Yoshiki-Iwasa/Arai60/pull/30
https://github.com/kazukiii/leetcode/pull/27
https://github.com/TORUS0818/leetcode/pull/28
https://github.com/nittoco/leetcode/pull/32
https://github.com/Ryotaro25/leetcode_first60/pull/28
https://github.com/goto-untrapped/Arai60/pull/50
https://github.com/hroc135/leetcode/pull/25
https://github.com/olsen-blue/Arai60/pull/26
